### PR TITLE
Add model selector dropdown

### DIFF
--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -1,0 +1,36 @@
+import {NextResponse} from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const provider = process.env.MODEL_PROVIDER || 'openrouter';
+  let models: string[] = [];
+  try {
+    if (provider === 'openrouter') {
+      const res = await fetch('https://openrouter.ai/api/v1/models', {
+        headers: {
+          Authorization: `Bearer ${process.env.OPENROUTER_API_KEY || ''}`,
+        },
+        cache: 'no-store',
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (Array.isArray(data.data)) {
+          models = data.data.map((m: any) => m.id);
+        }
+      }
+    } else if (provider === 'google') {
+      const url = `https://generativelanguage.googleapis.com/v1/models?key=${process.env.GOOGLE_AI_API_KEY || ''}`;
+      const res = await fetch(url, {cache: 'no-store'});
+      if (res.ok) {
+        const data = await res.json();
+        if (Array.isArray(data.models)) {
+          models = data.models.map((m: any) => m.name);
+        }
+      }
+    }
+  } catch (err) {
+    console.error('Model fetch error', err);
+  }
+  return NextResponse.json({models});
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,6 +22,7 @@ const LOCAL_STORAGE_KEYS = {
   ACTIVE_DOCUMENT_ID: 'jsonCanvas_activeDocumentId',
   API_KEY: 'google_ai_api_key',
   THEME: 'jsonCanvas_theme',
+  MODEL: 'jsonCanvas_model',
 };
 
 const initialJson: JsonValue = {
@@ -101,9 +102,10 @@ export default function Home() {
   const [isClient, setIsClient] = useState(false);
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [selectedModel, setSelectedModel] = useState('');
 
 
-  // Theme management
+  // Theme and model management
   useEffect(() => {
     if (!isClient) return;
     const storedTheme = localStorage.getItem(LOCAL_STORAGE_KEYS.THEME) as 'light' | 'dark' | null;
@@ -123,9 +125,14 @@ export default function Home() {
         localStorage.setItem(LOCAL_STORAGE_KEYS.THEME, 'dark');
       } else {
         setTheme('light');
-        document.documentElement.classList.remove('dark');
-        localStorage.setItem(LOCAL_STORAGE_KEYS.THEME, 'light');
-      }
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem(LOCAL_STORAGE_KEYS.THEME, 'light');
+    }
+  }
+
+    const storedModel = localStorage.getItem(LOCAL_STORAGE_KEYS.MODEL);
+    if (storedModel) {
+      setSelectedModel(storedModel);
     }
   }, [isClient]);
 
@@ -461,6 +468,11 @@ export default function Home() {
         onToggleSidebar={() => setIsSidebarOpen(!isSidebarOpen)}
         theme={theme}
         onToggleTheme={toggleTheme}
+        selectedModel={selectedModel}
+        onModelChange={(m) => {
+          setSelectedModel(m);
+          localStorage.setItem(LOCAL_STORAGE_KEYS.MODEL, m);
+        }}
       />
       <div className="flex flex-1 overflow-hidden">
         <DocumentSidebar

--- a/src/components/json-canvas/header.tsx
+++ b/src/components/json-canvas/header.tsx
@@ -4,7 +4,8 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { FileUp, FileDown, Undo2, Redo2, Settings, FileJson2, Github, ClipboardPaste, LayoutDashboard, Sun, Moon } from 'lucide-react'; 
+import { FileUp, FileDown, Undo2, Redo2, Settings, FileJson2, Github, ClipboardPaste, LayoutDashboard, Sun, Moon } from 'lucide-react';
+import { ModelSelector } from './model-selector';
 
 interface HeaderProps {
   onImport: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -15,10 +16,12 @@ interface HeaderProps {
   canRedo: boolean;
   onOpenApiKeyDialog: () => void;
   onOpenEditEntireJsonDialog: () => void;
-  onOpenQuickImportDialog: () => void; 
+  onOpenQuickImportDialog: () => void;
   onToggleSidebar: () => void;
   theme: 'light' | 'dark';
   onToggleTheme: () => void;
+  selectedModel: string;
+  onModelChange: (model: string) => void;
 }
 
 export function Header({
@@ -34,6 +37,8 @@ export function Header({
   onToggleSidebar,
   theme,
   onToggleTheme,
+  selectedModel,
+  onModelChange,
 }: HeaderProps) {
   const importInputRef = React.useRef<HTMLInputElement>(null);
 
@@ -111,7 +116,8 @@ export function Header({
               </TooltipTrigger>
               <TooltipContent><p>Redo (Ctrl+Y) in Active Document</p></TooltipContent>
             </Tooltip>
-             <Tooltip>
+            <ModelSelector value={selectedModel} onChange={onModelChange} />
+            <Tooltip>
               <TooltipTrigger asChild>
                 <Button variant="outline" size="icon" onClick={onToggleTheme}>
                   {theme === 'light' ? <Moon className="h-5 w-5" /> : <Sun className="h-5 w-5" />}

--- a/src/components/json-canvas/json-tree-editor.tsx
+++ b/src/components/json-canvas/json-tree-editor.tsx
@@ -27,15 +27,15 @@ export function JsonTreeEditor({ jsonData, onJsonChange, title, getApiKey }: Jso
   const [cardViewPath, setCardViewPath] = useState<JsonPath>([]);
   const { toast } = useToast();
 
-  const getCurrentCardData = useCallback((): JsonValue => {
+  const getCurrentCardData = useCallback((): JsonValue | undefined => {
     let currentData = jsonData;
     if (!cardViewPath.length) return currentData;
     try {
         for (const segment of cardViewPath) {
             if (typeof currentData !== 'object' || currentData === null || !(segment in (currentData as any))) {
-                 return undefined; 
+                 return undefined;
             }
-            currentData = (currentData as JsonObject | JsonArray)[segment as any];
+            currentData = (currentData as any)[segment as any];
         }
         return currentData;
     } catch (e) {
@@ -44,7 +44,7 @@ export function JsonTreeEditor({ jsonData, onJsonChange, title, getApiKey }: Jso
     }
   }, [jsonData, cardViewPath]);
 
-  const currentCardData = getCurrentCardData();
+  const currentCardData: JsonValue | undefined = getCurrentCardData();
 
   useEffect(() => {
     if (viewMode === 'cards') {

--- a/src/components/json-canvas/model-selector.tsx
+++ b/src/components/json-canvas/model-selector.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import React, { useEffect, useState } from 'react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { RefreshCcw, Loader2 } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+
+interface ModelSelectorProps {
+  value: string;
+  onChange: (model: string) => void;
+}
+
+export function ModelSelector({ value, onChange }: ModelSelectorProps) {
+  const [models, setModels] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const { toast } = useToast();
+
+  const fetchModels = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/models');
+      if (!res.ok) throw new Error('Failed to fetch models');
+      const data = await res.json();
+      setModels(Array.isArray(data.models) ? data.models : []);
+    } catch (err) {
+      console.error(err);
+      toast({
+        title: 'Failed to load models',
+        description: 'Could not fetch model list from provider.',
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchModels();
+  }, []);
+
+  return (
+    <div className="flex items-center space-x-2">
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className="min-w-[200px]">
+          <SelectValue placeholder="Select model" />
+        </SelectTrigger>
+        <SelectContent>
+          {models.map(model => (
+            <SelectItem key={model} value={model}>
+              {model}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button variant="ghost" size="icon" onClick={fetchModels} disabled={loading}>
+        {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCcw className="h-4 w-4" />}
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow querying model list from the backend
- provide API route to get models from OpenRouter (or Google)
- add ModelSelector dropdown component with refresh
- expose model selector in header and save choice in local storage
- adjust json-tree-editor types

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6856c3a9cc508323ac8a08c1d860f6ec