### PR TITLE
Update README with plugin switching instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ cp .env.example .env
 # then edit .env and set GOOGLE_AI_API_KEY
 ```
 
+## Switching Genkit Plugins
+
+`src/ai/genkit.ts` configures Genkit to use the Google AI plugin. To use a
+different provider, swap the plugin import and `plugins` array in that file.
+For example, with OpenRouter:
+
+```ts
+import {openrouter} from '@genkit-ai/openrouter';
+
+export const ai = genkit({
+  plugins: [openrouter()],
+  model: 'openrouter/gpt-4o',
+});
+```
+
+Add the provider's API key to `.env` (e.g., `OPENROUTER_API_KEY`) and restart
+the Genkit dev server.
+
 ## 🚀 Rapid Import & AI Formatting
 
 - **Paste Anything:** Instantly import data by pasting raw text, CSV, lists, or messy snippets. No need for perfect JSON.


### PR DESCRIPTION
## Summary
- document how to use a different Genkit plugin and where to set API keys

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run typecheck` *(fails: TypeScript errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6856c3a8429483239600b285692d6c4d