### PR TITLE
Hide model selector until API key provided

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -156,6 +156,8 @@ export default function Home() {
       const storedKey = localStorage.getItem(LOCAL_STORAGE_KEYS.API_KEY);
       if (storedKey) {
         setApiKey(storedKey);
+      } else {
+        setIsApiKeyDialogOpen(true);
       }
     } catch (error) {
       console.error("Error reading API key from localStorage:", error);
@@ -473,6 +475,7 @@ export default function Home() {
           setSelectedModel(m);
           localStorage.setItem(LOCAL_STORAGE_KEYS.MODEL, m);
         }}
+        hasApiKey={Boolean(apiKey)}
       />
       <div className="flex flex-1 overflow-hidden">
         <DocumentSidebar

--- a/src/components/json-canvas/header.tsx
+++ b/src/components/json-canvas/header.tsx
@@ -22,6 +22,7 @@ interface HeaderProps {
   onToggleTheme: () => void;
   selectedModel: string;
   onModelChange: (model: string) => void;
+  hasApiKey: boolean;
 }
 
 export function Header({
@@ -39,6 +40,7 @@ export function Header({
   onToggleTheme,
   selectedModel,
   onModelChange,
+  hasApiKey,
 }: HeaderProps) {
   const importInputRef = React.useRef<HTMLInputElement>(null);
 
@@ -116,7 +118,7 @@ export function Header({
               </TooltipTrigger>
               <TooltipContent><p>Redo (Ctrl+Y) in Active Document</p></TooltipContent>
             </Tooltip>
-            <ModelSelector value={selectedModel} onChange={onModelChange} />
+            <ModelSelector value={selectedModel} onChange={onModelChange} disabled={!hasApiKey} />
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button variant="outline" size="icon" onClick={onToggleTheme}>

--- a/src/components/json-canvas/model-selector.tsx
+++ b/src/components/json-canvas/model-selector.tsx
@@ -9,14 +9,16 @@ import { useToast } from '@/hooks/use-toast';
 interface ModelSelectorProps {
   value: string;
   onChange: (model: string) => void;
+  disabled?: boolean;
 }
 
-export function ModelSelector({ value, onChange }: ModelSelectorProps) {
+export function ModelSelector({ value, onChange, disabled }: ModelSelectorProps) {
   const [models, setModels] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const { toast } = useToast();
 
   const fetchModels = async () => {
+    if (disabled) return;
     setLoading(true);
     try {
       const res = await fetch('/api/models');
@@ -41,19 +43,21 @@ export function ModelSelector({ value, onChange }: ModelSelectorProps) {
 
   return (
     <div className="flex items-center space-x-2">
-      <Select value={value} onValueChange={onChange}>
-        <SelectTrigger className="min-w-[200px]">
-          <SelectValue placeholder="Select model" />
+      <Select value={value} onValueChange={onChange} disabled={disabled}>
+        <SelectTrigger className="min-w-[200px]" disabled={disabled}>
+          <SelectValue placeholder={disabled ? 'Set API key first' : 'Select model'} />
         </SelectTrigger>
-        <SelectContent>
-          {models.map(model => (
-            <SelectItem key={model} value={model}>
-              {model}
-            </SelectItem>
-          ))}
-        </SelectContent>
+        {!disabled && (
+          <SelectContent>
+            {models.map(model => (
+              <SelectItem key={model} value={model}>
+                {model}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        )}
       </Select>
-      <Button variant="ghost" size="icon" onClick={fetchModels} disabled={loading}>
+      <Button variant="ghost" size="icon" onClick={fetchModels} disabled={loading || disabled}>
         {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCcw className="h-4 w-4" />}
       </Button>
     </div>


### PR DESCRIPTION
## Summary
- disable model selector when API key missing
- expose `hasApiKey` prop on Header and pass from page
- automatically prompt for API key on first load

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_685768a263a48323bc24d6778caa043f